### PR TITLE
startupPage refresh

### DIFF
--- a/src/component/Nav.js
+++ b/src/component/Nav.js
@@ -1,21 +1,27 @@
 import img_logo from "../asset/images/img_logo.png";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import style from "../css/Nav.module.css";
 
 export default function Nav() {
   const location = useLocation();
+  const navigate = useNavigate();
   const currentPath = location.pathname;
 
   const isCompare = currentPath === "/compare";
   const isCompareStatus = currentPath === "/compare-status";
   const isInvestStatus = currentPath === "/invest-status";
 
+  const handleLogoClick = () => {
+    window.location.reload();
+    navigate("/");
+  };
+
   return (
     <div className={style.header}>
       <div className={style.nav}>
-        <Link to='/'>
-          <img className={style.logo} src={img_logo} alt="logo" />
-        </Link>
+        <div>
+          <img className={style.logo} src={img_logo} alt="logo" onClick={handleLogoClick} />
+        </div>
         <div className={style.titleGroup}>
           <Link
             className={`${style.title} ${isCompare ? style.active : ""}`}

--- a/src/component/Nav.js
+++ b/src/component/Nav.js
@@ -12,8 +12,8 @@ export default function Nav() {
   const isInvestStatus = currentPath === "/invest-status";
 
   const handleLogoClick = () => {
-    window.location.reload();
     navigate("/");
+    window.location.reload();
   };
 
   return (

--- a/src/css/Nav.module.css
+++ b/src/css/Nav.module.css
@@ -21,6 +21,7 @@
 .logo {
   width: 11.2rem;
   height: 4rem;
+  cursor: pointer;
 }
 
 .titleGroup {

--- a/src/pages/StartupPage.js
+++ b/src/pages/StartupPage.js
@@ -39,7 +39,6 @@ export default function StartupPage() {
     };
 
     fetchData();
-    console.log(search);
   }, [currentPage, sortType, search]);
 
   // 데이터 정렬 함수


### PR DESCRIPTION
## 이슈 번호

- close #67

## 작업 사항
- 로고 클릭 시 reload 되면서 /로 이동

## 기타
nav에서 app으로 prop 넘겨서 다시 outlet에서 startupPage로 받아서 검색어 빈문자열로 들어가서 다시 fetch 받아오게 구현하고 싶었는데 좀 오래 걸릴거같아서 일단 그냥 로고 누르면 reload되고 /로 이동되도록 변경하였습니다..
지금 방식은 너무 오래걸리기도 하고 강제로 reload하는 형식이라 수정해야할거같긴합니다
더 찾아보고 중간 이후에 더 나은 로직 있으면 적용해보도록 하겠습니다