### PR TITLE
공통 컴포넌트 제작 피드

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,8 +1,7 @@
 import axios from "axios";
 
 const instance = axios.create({
-  baseURL: "https://two-viewmystartup-2team-be.onrender.com/api",
-  //"http://localhost:3000/api"
+  baseURL: "https://two-viewmystartup-2team-be.onrender.com/api"
   // timeout: 10000,
 });
 

--- a/src/component/CompanyInfoTable.js
+++ b/src/component/CompanyInfoTable.js
@@ -23,24 +23,22 @@ function CompanyInfoTable({
     return result;
   };
   const selectMenuName = () => {
+    const pcMessage = "View My Startup 투자 금액";
+    const tabletMessage = (
+      <>
+        View My Startup
+        <br />
+        투자 금액
+      </>
+    );
     const result = isCompareStatus
       ? ["나의 기업 선택 횟수", "비교 기업 선택 횟수"]
       : isInvestment
-      ? [
-          isTablet ? (
-            <>
-              View My Startup
-              <br />
-              투자 금액
-            </>
-          ) : (
-            "View My Startup 투자 금액"
-          ),
-          "실제 누적 투자 금액"
-        ]
+      ? [isTablet ? tabletMessage : pcMessage, "실제 누적 투자 금액"]
       : ["누적 투자 금액", "매출액", "고용 인원"];
     return result;
   };
+  const selectMenuNames = selectMenuName();
   const handleError = (e) => (e.target.src = defaultLogo);
   const isHighLight = (company) =>
     company.id === highLightId ? styles.highLight : "";
@@ -69,18 +67,19 @@ function CompanyInfoTable({
           <div className={styles.cell}>기업 명</div>
           <div className={styles.cell}>기업 소개</div>
           <div className={styles.cell}>카테고리</div>
-          {selectMenuName().map((menu, index) => (
+          {selectMenuNames.map((menu, index) => (
             <div className={styles.cell} key={menu}>
               {menu}
             </div>
           ))}
         </div>
         {list.map((company) => (
-          <Link to={`/companies/${company.id}`} className={styles.link}>
-            <div
-              className={`${row} ${isHighLight(company)}`}
-              key={company.name}
-            >
+          <Link
+            to={`/companies/${company.id}`}
+            className={styles.link}
+            key={company.id}
+          >
+            <div className={`${row} ${isHighLight(company)}`}>
               {!isCompareResult && (
                 <div className={styles.cell}>{company.rank}위</div>
               )}

--- a/src/component/CompanyInfoTable.js
+++ b/src/component/CompanyInfoTable.js
@@ -48,12 +48,13 @@ function CompanyInfoTable({
     const comparedChosenCount = company.comparedChosenCount;
     const totalInvestment = `${ConvertBillion(company.totalInvestment)} 원`;
     const virtualInvestment = `${ConvertBillion(company.virtualInvestment)} 원`;
+    const actualInvestment = `${ConvertBillion(company.actualInvestment)} 원`;
     const revenue = `${ConvertBillion(company.revenue)} 원`;
     const employee = company.employee;
     const result = isCompareStatus
       ? [myChosenCount, comparedChosenCount]
       : isInvestment
-      ? [virtualInvestment, totalInvestment]
+      ? [virtualInvestment, actualInvestment]
       : [totalInvestment, revenue, employee];
     return result;
   };

--- a/src/component/CompanyInfoTable.js
+++ b/src/component/CompanyInfoTable.js
@@ -1,0 +1,110 @@
+import styles from "../css/CompanyInfoTable.module.css";
+import { Link } from "react-router-dom";
+import ConvertBillion from "../utils/ConvertBillion.js";
+import defaultLogo from "../asset/images/img_company_default_logo.png";
+function CompanyInfoTable({
+  type = "standard",
+  list,
+  highLightId = "",
+  className = ""
+}) {
+  const isTablet = window.innerWidth <= 1199;
+  const isCompareResult = type === "compareResult";
+  const isCompareStatus = type === "compareStatus";
+  const isInvestment = type === "investmentStatus";
+  const selectClass = (element) => {
+    const result = isCompareResult
+      ? `${element} : ${styles.compareResult}`
+      : isCompareStatus
+      ? `${element} ${styles.compareStatus}`
+      : isInvestment
+      ? `${element} : ${styles.investmentStatus}`
+      : `${element} ${styles.standard}`;
+    return result;
+  };
+  const selectMenuName = () => {
+    const result = isCompareStatus
+      ? ["나의 기업 선택 횟수", "비교 기업 선택 횟수"]
+      : isInvestment
+      ? [
+          isTablet ? (
+            <>
+              View My Startup
+              <br />
+              투자 금액
+            </>
+          ) : (
+            "View My Startup 투자 금액"
+          ),
+          "실제 누적 투자 금액"
+        ]
+      : ["누적 투자 금액", "매출액", "고용 인원"];
+    return result;
+  };
+  const handleError = (e) => (e.target.src = defaultLogo);
+  const isHighLight = (company) =>
+    company.id === highLightId ? styles.highLight : "";
+
+  const seletedMenuValue = (company) => {
+    const myChosenCount = company.myChosenCount;
+    const comparedChosenCount = company.comparedChosenCount;
+    const totalInvestment = `${ConvertBillion(company.totalInvestment)} 원`;
+    const virtualInvestment = `${ConvertBillion(company.virtualInvestment)} 원`;
+    const revenue = `${ConvertBillion(company.revenue)} 원`;
+    const employee = company.employee;
+    const result = isCompareStatus
+      ? [myChosenCount, comparedChosenCount]
+      : isInvestment
+      ? [virtualInvestment, totalInvestment]
+      : [totalInvestment, revenue, employee];
+    return result;
+  };
+  const header = selectClass(styles.header);
+  const row = selectClass(styles.row);
+  return (
+    <div className={`${styles.tableContainer} ${className}`}>
+      <div className={styles.table}>
+        <div className={header}>
+          {!isCompareResult && <div className={styles.cell}>순위</div>}
+          <div className={styles.cell}>기업 명</div>
+          <div className={styles.cell}>기업 소개</div>
+          <div className={styles.cell}>카테고리</div>
+          {selectMenuName().map((menu, index) => (
+            <div className={styles.cell} key={menu}>
+              {menu}
+            </div>
+          ))}
+        </div>
+        {list.map((company) => (
+          <Link to={`/companies/${company.id}`} className={styles.link}>
+            <div
+              className={`${row} ${isHighLight(company)}`}
+              key={company.name}
+            >
+              {!isCompareResult && (
+                <div className={styles.cell}>{company.rank}위</div>
+              )}
+              <div className={styles.nameAndLogo}>
+                <img
+                  className={styles.logo}
+                  src={company.logo}
+                  alt="회사 로고 이미지"
+                  onError={handleError}
+                />
+                <div className={styles.name}>{company.name}</div>
+              </div>
+              <div className={styles.description}>{company.description}</div>
+              <div className={styles.cell}>{company.category}</div>
+              {seletedMenuValue(company).map((value) => (
+                <div className={styles.cell} key={value}>
+                  {value}
+                </div>
+              ))}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+export default CompanyInfoTable;

--- a/src/css/CompanyInfoTable.module.css
+++ b/src/css/CompanyInfoTable.module.css
@@ -108,7 +108,7 @@
 }
 
 .name {
-    max-width: 10rem;
+    max-width: 12rem;
     -webkit-line-clamp: 1;
     color: #ffffff;
 }
@@ -147,6 +147,10 @@
     .logo {
         margin-left: 1.6rem;
         margin-right: 0.8rem;
+    }
+
+    .name {
+        max-width: 7.2rem;
     }
 }
 

--- a/src/css/CompanyInfoTable.module.css
+++ b/src/css/CompanyInfoTable.module.css
@@ -38,11 +38,11 @@
     border-bottom: 0.1rem solid #4B4B4B;
 }
 
-.table>a:first-child .row {
+.table>.link:first-of-type .row {
     border-radius: 0.4rem 0.4rem 0 0;
 }
 
-.table>a:last-child .row {
+.table>.link:last-child .row {
     border-radius: 0 0 0.4rem 0.4rem;
     border-bottom: none;
 }

--- a/src/css/CompanyInfoTable.module.css
+++ b/src/css/CompanyInfoTable.module.css
@@ -26,7 +26,7 @@
     background: #2E2E2E;
     color: #ffffff;
     font-weight: 500;
-
+    border-radius: 0.4rem;
 }
 
 .row {
@@ -38,14 +38,21 @@
     border-bottom: 0.1rem solid #4B4B4B;
 }
 
+.table>a:first-child .row {
+    border-radius: 0.4rem 0.4rem 0 0;
+}
+
+.table>a:last-child .row {
+    border-radius: 0 0 0.4rem 0.4rem;
+    border-bottom: none;
+}
+
 .row.standard.highLight,
 .row.compareResult.highLight {
     background: #2E2E2E;
 }
 
-.row:last-child {
-    border: none;
-}
+
 
 .standard,
 .compareResult,
@@ -101,7 +108,7 @@
 }
 
 .name {
-    max-width: 15rem;
+    max-width: 10rem;
     -webkit-line-clamp: 1;
     color: #ffffff;
 }

--- a/src/css/CompanyInfoTable.module.css
+++ b/src/css/CompanyInfoTable.module.css
@@ -1,0 +1,171 @@
+.link {
+    text-decoration: none;
+    /* 밑줄 제거 */
+    color: black;
+    /* 링크 색상 변경 (필요시) */
+}
+
+.tableContainer {
+    width: 120rem;
+    display: flex;
+    justify-content: left;
+}
+
+.table {
+    width: 100%;
+    font-size: 1.4rem;
+    line-height: 1.671rem;
+    white-space: nowrap;
+    margin: 0;
+    padding: 0;
+}
+
+.header {
+    height: 3.9rem;
+    margin-bottom: 1.6rem;
+    background: #2E2E2E;
+    color: #ffffff;
+    font-weight: 500;
+
+}
+
+.row {
+    height: 6.4rem;
+    color: #D8D8D8;
+    background: #212121;
+    font-weight: 400;
+    text-align: left;
+    border-bottom: 0.1rem solid #4B4B4B;
+}
+
+.row.standard.highLight,
+.row.compareResult.highLight {
+    background: #2E2E2E;
+}
+
+.row:last-child {
+    border: none;
+}
+
+.standard,
+.compareResult,
+.compareStatus,
+.investmentStatus {
+    display: grid;
+}
+
+.standard {
+    grid-template-columns: 6.8rem 21.3rem 30.4rem 1fr 1fr 1fr 1fr;
+}
+
+.compareResult {
+    grid-template-columns: 21.3rem 30.4rem 1fr 1fr 1fr 1fr;
+}
+
+.compareStatus,
+.investmentStatus {
+    grid-template-columns: 6.8rem 21.3rem 30.4rem 15.375rem 1fr 1fr;
+}
+
+.cell {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
+.nameAndLogo {
+    display: flex;
+    align-items: center;
+}
+
+.logo {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 3.2rem;
+    height: 3.2rem;
+    border-radius: 50%;
+    margin-left: 2.4rem;
+    margin-right: 1.2rem;
+}
+
+.name,
+.description {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    white-space: normal;
+    word-break: break-word;
+}
+
+.name {
+    max-width: 15rem;
+    -webkit-line-clamp: 1;
+    color: #ffffff;
+}
+
+.description {
+    padding: 1.5rem 1.6rem;
+    line-height: 1.671rem;
+    height: 4.842rem;
+    max-width: 30.4rem;
+    -webkit-line-clamp: 2;
+    text-align: left;
+}
+
+@media(max-width: 1199px) {
+    .tableContainer {
+        width: 69.6rem;
+    }
+
+    .table {
+        font-size: 1.3rem;
+    }
+
+    .standard {
+        grid-template-columns: 6rem 14rem 18rem 8rem 1fr 1fr 1fr;
+    }
+
+    .compareResult {
+        grid-template-columns: 15rem 18rem 1fr 1fr 1fr 1fr;
+    }
+
+    .compareStatus,
+    .investmentStatus {
+        grid-template-columns: 6rem 14rem 18rem 8.4rem 1fr 1fr;
+    }
+
+    .logo {
+        margin-left: 1.6rem;
+        margin-right: 0.8rem;
+    }
+}
+
+@media(max-width: 743px) {
+    .tableContainer {
+        width: 36rem;
+        overflow-x: auto;
+    }
+
+    .table {
+        min-width: 80rem;
+        padding-bottom: 1.2rem;
+    }
+
+    .tableContainer::-webkit-scrollbar {
+        height: 1.2rem;
+    }
+
+    .tableContainer::-webkit-scrollbar-track {
+        background: #212121;
+        border-radius: 0.8rem;
+    }
+
+    .tableContainer::-webkit-scrollbar-thumb {
+        background: #131313;
+        border-radius: 0.8rem;
+        border: 0.2rem solid #212121;
+    }
+}

--- a/src/pages/CompareResultPage.js
+++ b/src/pages/CompareResultPage.js
@@ -24,6 +24,7 @@ function CompareResultPage() {
   const myCompany = compStatus.list.find(
     (company) => company.id === myCompanyId
   );
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const openModal = () => setIsModalOpen(true);
@@ -82,7 +83,7 @@ function CompareResultPage() {
           type={"standard"}
         />
         <CompanyInfoTable
-          list={compStatus.list}
+          list={rankStatus.list}
           className={styles.selectedCompanyCardLayout}
           highLightId={myCompany.id}
           type={"compareResult"}
@@ -106,7 +107,7 @@ function CompareResultPage() {
           sortOption="list"
           myCompany={myCompany}
         /> */}
-        <ComparisonTable
+        {/* <ComparisonTable
           type="ranking"
           className={styles.rankingTableLayout}
           list={rankStatus.list}
@@ -114,7 +115,7 @@ function CompareResultPage() {
           defaultOption={rankStatus.sort}
           sortOption="list"
           myCompany={myCompany}
-        />
+        /> */}
         <button onClick={openModal} className={styles.investBtn}>
           나의 기업에 투자하기
         </button>

--- a/src/pages/CompareResultPage.js
+++ b/src/pages/CompareResultPage.js
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { getRankAndNearbyCompanies } from "../api/CompareResultAPI.js";
 import useFetchCompanyData from "../hooks/useFetchCompanyData.js";
 import sortData from "../utils/sortData.js";
+import CompanyInfoTable from "../component/CompanyInfoTable.js";
 
 function CompareResultPage() {
   const location = useLocation();
@@ -74,7 +75,29 @@ function CompareResultPage() {
           myCompany={myCompany}
           className={styles.selectedCompanyCardLayout}
         />
-        <ComparisonTable
+        <CompanyInfoTable
+          list={rankStatus.list}
+          className={styles.selectedCompanyCardLayout}
+          highLightId={myCompany.id}
+          type={"standard"}
+        />
+        <CompanyInfoTable
+          list={compStatus.list}
+          className={styles.selectedCompanyCardLayout}
+          highLightId={myCompany.id}
+          type={"compareResult"}
+        />
+        <CompanyInfoTable
+          list={rankStatus.list}
+          className={styles.selectedCompanyCardLayout}
+          type={"compareStatus"}
+        />
+        <CompanyInfoTable
+          list={rankStatus.list}
+          className={styles.selectedCompanyCardLayout}
+          type={"investmentStatus"}
+        />
+        {/* <ComparisonTable
           type="select"
           className={styles.selectTableLayout}
           list={compStatus.list}
@@ -82,7 +105,7 @@ function CompareResultPage() {
           defaultOption={compStatus.sort}
           sortOption="list"
           myCompany={myCompany}
-        />
+        /> */}
         <ComparisonTable
           type="ranking"
           className={styles.rankingTableLayout}

--- a/src/pages/InvestStatusPage.js
+++ b/src/pages/InvestStatusPage.js
@@ -31,7 +31,7 @@ export default function InvestStatusPage() {
         const response = await getInvestmentList({
           page: currentPage,
           limit: ITEM_LIMIT,
-          order: sortType,
+          order: sortType
         });
 
         if (response) {
@@ -47,7 +47,6 @@ export default function InvestStatusPage() {
     fetchData();
   }, [currentPage, sortType]);
 
-    
   // 데이터 정렬 함수
   const sortData = (data, option) => {
     switch (option) {
@@ -83,22 +82,24 @@ export default function InvestStatusPage() {
       </div>
       <div className={style.body}>
         <div className={style.table}>
-        <div className={style.listHeader}>
-          <div className={style.rank}>순위</div>
-          <div className={style.company}>기업 명</div>
-          <div className={style.description}>기업 소개</div>
-          <div className={style.category}>카테고리</div>
-          <div className={style.other}>View My Startup {windowSize < 1000 && <br />}투자 금액</div>
-          <div className={style.other}>실제 누적 투자 금액</div>
+          <div className={style.listHeader}>
+            <div className={style.rank}>순위</div>
+            <div className={style.company}>기업 명</div>
+            <div className={style.description}>기업 소개</div>
+            <div className={style.category}>카테고리</div>
+            <div className={style.other}>
+              View My Startup {windowSize < 1000 && <br />}투자 금액
+            </div>
+            <div className={style.other}>실제 누적 투자 금액</div>
+          </div>
+          <StartupList
+            currentPage={currentPage}
+            itemLimit={ITEM_LIMIT}
+            data={sortedData}
+            isStatusPage={true}
+            isCompareStatus={false}
+          />
         </div>
-        <StartupList
-          currentPage={currentPage}
-          itemLimit={ITEM_LIMIT}
-          data={sortedData}
-          isStatusPage={true}
-          isCompareStatus={false}
-        />
-      </div>
       </div>
       <SPagination
         currentPage={currentPage} // 현재 페이지 번호

--- a/src/pages/InvestStatusPage.js
+++ b/src/pages/InvestStatusPage.js
@@ -4,7 +4,7 @@ import StartupList from "../component/StartupList.js";
 import style from "../css/InvestStatusPage.module.css";
 import SPagination from "../component/SPagination.js";
 import SortContent from "../component/SortContent.js";
-
+import CompanyInfoTable from "../component/CompanyInfoTable.js";
 const ITEM_LIMIT = 10;
 
 export default function InvestStatusPage() {
@@ -69,6 +69,7 @@ export default function InvestStatusPage() {
   };
 
   const sortedData = sortData([...investmentData], sortType);
+  const testData = sortedData.slice(0, 10);
 
   return (
     <div className={style.container}>
@@ -107,6 +108,7 @@ export default function InvestStatusPage() {
         totalCount={totalCount} // 전체 데이터 수
         itemLimit={ITEM_LIMIT}
       />
+      <CompanyInfoTable list={testData} type={"investmentStatus"} />
     </div>
   );
 }


### PR DESCRIPTION
## 이슈 번호

- close https://github.com/2-ViewMyStartup-2-FE/2-ViewMyStartup-2team-FE/issues/104

## 작업 사항
- [x] 모든 페이지에 적절하게 잘 보인다

## 기타
netlify : https://viewmystartup.netlify.app/compare-result?mycompany=3d16cb4c-911e-75c0-de5a-15c316b39f98&selectedcompany=5429709f-5e15-bacb-76d5-73c5ce00f938,d70777cc-14bd-2416-0692-5a483781b78b,56e82b22-7466-b00b-9035-57ad7b584f65,b511c660-5bea-3583-4987-af99b38aec0d
링크는 제가 보여주기 위해 결과페이지에 만든 모든 타입의 테이블을 띄워놨습니다
투자 현황 페이지는 화면의 크기에 대한 상태값이 필요해서 투자 현황 페이지 기존 테이블 밑에 하나 더 만들어뒀습니다.
## 주의사항
이 PR은 merge가 되면 안됩니다 그저 만들어진 모든 타입의 테이블을 보여주고 피드백 받기 위해 만들어진 PR이고
피드사항 수정 후 컴포넌트만 생성된 채로 PR을 올리거나 제 페이지만 적용한 후 다시 PR을 올릴 예정입니다.

이게 더 낫지 않을까? 짜는 로직의 문제점? 사소한 css 하나도 얘기해주세요.
투자 현황 테이블은 화면의 크기를 상태값으로 가져야 하기 때문에 상태값이 있는 투자 현황 페이지에 하나 더 만들어뒀습니다.

## 문제점
1. 반응형 css의 화면 크기 조건이 다른거 같아서 목요일날 한번 얘기해보고자 합니다
2. 현재 피그마 상에서는 글씨 크기가 모바일 화면에서만 작아지는데 제 생각에는 아무리 봐도 타블릿 환경에서 부터 작아지는게 맞다고 생각하여 2번째 미디어 조건에 글씨 크기를 바꿨습니다.
3. 스타트업 리스트 테이블은 standard 타입으로 비교 결과페이지에서 쓰이는데 highLightId prop에 회사의 id를 주면 id가 동일한 회사는 하이라이팅이 되게 해놨습니다 값이 드가지 않는다면 문제 없을거 같아요.
4. 기업 명의 ...생략의 max-width 값을 pc에서는 12rem 태블릿에서는 7.2rem으로 해둔 상황입니다
5. 브랜치명이 잘못 되어 있는데 피드 다받고 수정할 때 제대로 쓰겠습니다