### PR TITLE
조 단위도 계산하는 formatAmount 함수 추가

### DIFF
--- a/src/component/CompanyInfoTable.js
+++ b/src/component/CompanyInfoTable.js
@@ -1,6 +1,7 @@
 import styles from "../css/CompanyInfoTable.module.css";
 import { Link } from "react-router-dom";
 import ConvertBillion from "../utils/ConvertBillion.js";
+import formatAmount from "../utils/formatAmount.js";
 import defaultLogo from "../asset/images/img_company_default_logo.png";
 function CompanyInfoTable({
   type = "standard",
@@ -46,11 +47,11 @@ function CompanyInfoTable({
   const seletedMenuValue = (company) => {
     const myChosenCount = company.myChosenCount;
     const comparedChosenCount = company.comparedChosenCount;
-    const totalInvestment = `${ConvertBillion(company.totalInvestment)} 원`;
-    const virtualInvestment = `${ConvertBillion(company.virtualInvestment)} 원`;
-    const actualInvestment = `${ConvertBillion(company.actualInvestment)} 원`;
-    const revenue = `${ConvertBillion(company.revenue)} 원`;
-    const employee = company.employee;
+    const totalInvestment = formatAmount(company.totalInvestment);
+    const virtualInvestment = formatAmount(company.virtualInvestment);
+    const actualInvestment = formatAmount(company.actualInvestment);
+    const revenue = formatAmount(company.revenue);
+    const employee = `${company.employee}명`;
     const result = isCompareStatus
       ? [myChosenCount, comparedChosenCount]
       : isInvestment

--- a/src/utils/formatAmount.js
+++ b/src/utils/formatAmount.js
@@ -1,0 +1,16 @@
+import bigInt from "big-integer";
+
+export default function formatAmount(amount) {
+  const bigIntAmount = bigInt(amount);
+  const billion = bigInt(100000000); //n을 붙이면 bigInt 라이브러리와는 별개의 bigInt가 사용됨
+  const trillion = bigInt(1000000000000);
+
+  if (bigIntAmount.geq(trillion)) {
+    //amount가 trillion보다 같거나 크다 조건문 bigInt라이브러리 메소드
+    const trillions = bigIntAmount.divide(trillion).toString(); // 조 계산 divide는 bigInt라이브러리 메소드
+    const billions = bigIntAmount.mod(trillion).divide(billion).toString(); // 억 계산 toString가 bigInt라이브러리에 사용시 소수점 사라짐
+    return `${trillions}조 ${billions}억 원`;
+  } else {
+    return `${bigIntAmount.divide(billion)}억 원`;
+  }
+}


### PR DESCRIPTION
## 이슈 번호

- close https://github.com/2-ViewMyStartup-2-FE/2-ViewMyStartup-2team-FE/issues/116

## 작업 사항
- [x] 조 단위도 숫자가 잘 나온다
- [x] 테이블 컴포넌트에 고용인원 '명'이 붙지 않아서 수정했습니다.

## 기타

netlify : https://viewmystartup.netlify.app/compare-result?mycompany=21e77067-5537-408e-cad7-e5e72bb6ad86&selectedcompany=5f2b40b8-d1b3-d323-d81a-b7a8e89553d0,180ebf67-68d0-2316-e93d-8e1e546330ba,bf4d7b0e-b34d-2fd8-d292-6049c4f7efc7,3d16cb4c-911e-75c0-de5a-15c316b39f98,e56b0ceb-bb30-bbec-805e-d5dc7412dcb1

## 기타
