### PR TITLE
비교결과 테이블 첫 렌더시에 정렬이 안되는 문제 해결

### DIFF
--- a/src/hooks/useFetchCompanyData.js
+++ b/src/hooks/useFetchCompanyData.js
@@ -5,11 +5,11 @@ import sortData from "../utils/sortData.js";
 
 const useFetchCompanyData = (myCompanyId, selectedCompaniesId) => {
   const [compStatus, setCompStatus] = useState({
-    sort: "누적 투자금액 높은순",
+    sort: "investmentHighest",
     list: []
   });
   const [rankStatus, setRankStatus] = useState({
-    sort: "누적 투자금액 높은순",
+    sort: "investmentHighest",
     list: []
   });
   const dataFetchedRef = useRef(false);
@@ -25,13 +25,12 @@ const useFetchCompanyData = (myCompanyId, selectedCompaniesId) => {
 
         const compList = sortData(
           [myCompanyData, ...selectedCompanies],
-          "누적 투자금액 높은순"
+          "investmentHighest"
         );
         setCompStatus((prev) => ({
           ...prev,
           list: compList
         }));
-
         const rankList = await getRankAndNearbyCompanies({ myCompanyId });
         setRankStatus((prev) => ({
           ...prev,

--- a/src/pages/CompareResultPage.js
+++ b/src/pages/CompareResultPage.js
@@ -32,24 +32,6 @@ function CompareResultPage() {
   };
   const closeModal = () => setIsModalOpen(false);
   const closePopup = () => setIsPopupOpen(false);
-  // const convertStateToUrl = (selectedOption) => {
-  //   switch (selectedOption) {
-  //     case "누적 투자금액 높은순":
-  //       return "investmentHighest";
-  //     case "누적 투자금액 낮은순":
-  //       return "investmentLowest";
-  //     case "매출액 높은순":
-  //       return "revenueHighest";
-  //     case "매출액 낮은순":
-  //       return "revenueLowest";
-  //     case "고용 인원 많은순":
-  //       return "employeeHighest";
-  //     case "고용 인원 적은순":
-  //       return "employeeLowest";
-  //     default:
-  //       return "investmentHighest";
-  //   }
-  // };
   const handleCompSelect = (selectedOption) => {
     setCompStatus((prev) => ({
       sort: selectedOption,


### PR DESCRIPTION
## 이슈 번호

- close https://github.com/2-ViewMyStartup-2-FE/2-ViewMyStartup-2team-FE/issues/142

## 작업 사항
- [x] 비교 결과 페이지를 접속했을 때 비교결과테이블의 정렬이 잘 된다

## 기타
netlify: https://viewmystartup.netlify.app/